### PR TITLE
Update init.cpp to allow for the plugin to be used in the English version.

### DIFF
--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -677,7 +677,7 @@ HMODULE WINAPI init_t::LoadLibraryAWrap(LPCSTR lpLibFileName) {
 		if (GLOBAL::exedit_hmod != nullptr)return ret;
 		if (*reinterpret_cast<int*>(GLOBAL::aviutl_base + OFS::AviUtl::vram_yc_size) == 2)return ret; // YUY2FilterMode
 		auto filters = reinterpret_cast<AviUtl::GetFilterTableList_t>(GetProcAddress(ret, reinterpret_cast<LPCSTR>(GLOBAL::aviutl_base + OFS::AviUtl::str_GetFilterTableList)))();
-		if (strcmp(filters[0]->information, "拡張編集(exedit) version 0.92 by ＫＥＮくん") != 0) {
+		if (strcmp(filters[0]->information, "拡張編集(exedit) version 0.92 by ＫＥＮくん") + strcmp(filters[0]->information, "Advanced Editing version 0.92") != 1) {
 			MessageBoxW(NULL, L"patch.aul requires Exedit version *0.92*.\n拡張編集 version 0.92以外では動作しません．", L"patch.aul", MB_ICONEXCLAMATION);
 			return ret;
 		}


### PR DESCRIPTION
**関係する Issue**
関係する Issue の番号を以下に書いてください。
- #105 from https://github.com/ePi5131/patch.aul/issues/105
- #105号 https://github.com/ePi5131/patch.aul/issues/105 より

**変更点**
この PR での変更点について教えてください。
- Addition of a line that allows the plugin to be used in the English translated version.
- 英語翻訳版でプラグインを利用できるようにするための行を追加する。

**内容の精査**
以下の点について教えてください。
- [x] コードにおかしな点がないことを確認しました。
- [x] 実際にビルドして試しました。

備考
Parts of this description has been translated using DeepL. I have all the requirements for building patch.aul but I couldn't compile the plugin because of an issue with cl.hpp giving syntax errors. This uses code from https://github.com/ePi5131/patch.aul/issues/105.
この説明の一部は DeepL を使用して翻訳されています。私の方では patch.aul をビルドするための要件はすべて整っていますが、cl.hpp の構文エラーに問題があり、プラグインをコンパイルできませんでした。https://github.com/ePi5131/patch.aul/issues/105 にあるコードを使用しました。